### PR TITLE
Remove old versions of tor-browser

### DIFF
--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -1686,6 +1686,9 @@ tb_patch() {
 }
 
 tb_move_old_version() {
+   shopt -s nullglob
+   local keep_counter
+
    if [ "$TB_NO_MOVE_OLD_VERSION" = "true" ]; then
       true "INFO: Skipping $FUNCNAME, because TB_NO_MOVE_OLD_VERSION is 'true', ok."
       return 0
@@ -1695,6 +1698,28 @@ tb_move_old_version() {
       output_echo_only "INFO: Moving old folder $tb_browser_folder..."
       mv "$tb_browser_folder" "$tb_browser_folder.old.$(date '+%F-%H:%M:%S')"
    fi
+
+   if [ -z "$TB_KEEP_OLD_VERSIONS_COUNT" ]; then
+      TB_KEEP_OLD_VERSIONS_COUNT=3
+   fi
+   if [ "$TB_KEEP_OLD_VERSIONS_COUNT" = "all" ]; then
+      true "INFO: Keeping all old versions because TB_KEEP_OLD_VERSIONS_COUNT set to 'all', ok."
+      return 0
+   fi
+
+   keep_count="$TB_KEEP_OLD_VERSIONS_COUNT"
+
+   for old_folder in $(ls -r "$tb_browser_folder.old."*); do
+      if ! [ -d "$old_folder" ]; then
+         continue
+      fi
+      if [ "$keep_count" -eq 0 ]; then
+         output_echo_only "INFO: Removing '$old_folder'"
+         rm -rf "$old_folder"
+      else
+         ((keep_count--))
+      fi
+   done
 }
 
 tb_install() {


### PR DESCRIPTION
Do not accumulate them indefinitely. By default keep last 3 versions -
when user have made some customization, he/she will be able to migrate
them to newer version. This limit is customizable with
TB_KEEP_OLD_VERSIONS_COUNT - set it either to a number of previous
versions to keep, or "all" to keep them all (previous behaviour).

Fixes https://phabricator.whonix.org/T671

Alternatively, if you wish to have this on Qubes-Whonix only, the default here may be set to "all", then add `/etc/torbrowser.d/30_qubes.conf` (to some Qubes-only package - like qubes-whonix-workstation) with appropriate override.
Also `TB_KEEP_OLD_VERSIONS_COUNT` should be documented somewhere, but I don't know where it a place for it (can't find documentation for other `TB_*` variables).