### PR TITLE
Add support for downloading to a separate path for an i2p-specific Tor Browser

### DIFF
--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -299,8 +299,11 @@ tb_parse_cmd_options() {
                shift
                ;;
            --i2p)
-               tb_install_folder="i2pb"
-               tb_proxy_name="i2p"
+               ## This option downloads a Tor Browser Bundle to a custom path,
+               ## intended to be used with i2p. It does no modification to the
+               ## browser itself.
+               export tb_install_folder="i2pb"
+               export tb_proxy_name="i2p"
                shift
                ;;
            --)
@@ -402,7 +405,7 @@ export -f outputfunc
 tb_config_folder_parser() {
    shopt -s nullglob
    local i
-   for i in /etc/torbrowser.d/*.conf /rw/config/torbrowser.d/*.conf; do
+   for i in /etc/"$tb_proxy_name"browser.d/*.conf /rw/config/"$tb_proxy_name"browser.d/*.conf; do
       bash -n "$i"
       source "$i"
    done

--- a/usr/bin/update-torbrowser
+++ b/usr/bin/update-torbrowser
@@ -85,9 +85,10 @@ tb_error_handler() {
 <br></br>###########################################################</p>"
 
    [ -n "$tb_user_home" ] || tb_user_home=~
+   [ -n "$tb_install_folder" ] || tb_install_folder="tb"
 
-   mkdir --parents "$tb_user_home/.cache/tb"
-   echo "$MSG" >> "$tb_user_home/.cache/tb/torbrowser_updater_error.log"
+   mkdir --parents "$tb_user_home/.cache/$tb_install_folder"
+   echo "$MSG" >> "$tb_user_home/.cache/$tb_install_folder/torbrowser_updater_error.log"
 
    ## In case variable output is not set yet.
    [ -n "$output" ] || output="output"
@@ -295,6 +296,11 @@ tb_parse_cmd_options() {
                ##      Therefore also implying '--ordinary' progress bar when
                ##      using --resume.
                [ -n "$ordinary" ] || ordinary="true"
+               shift
+               ;;
+           --i2p)
+               tb_install_folder="i2pb"
+               tb_proxy_name="i2p"
                shift
                ;;
            --)
@@ -557,13 +563,15 @@ tb_preparation() {
       fi
    fi
 
-   [ -n "$tb_home_folder" ] || tb_home_folder="$tb_user_home/.tb"
-   [ -n "$tb_browser_folder" ] || tb_browser_folder="$tb_home_folder/tor-browser"
-   [ -n "$tb_cache_folder" ] || tb_cache_folder="$tb_user_home/.cache/tb"
+   [ -n "$tb_install_folder" ] || tb_install_folder="tb"
+   [ -n "$tb_home_folder" ] || tb_home_folder="$tb_user_home/.$tb_install_folder"
+   [ -n "$tb_proxy_name" ] || tb_proxy_name="tor"
+   [ -n "$tb_browser_folder" ] || tb_browser_folder="$tb_home_folder/$tb_proxy_name-browser"
+   [ -n "$tb_cache_folder" ] || tb_cache_folder="$tb_user_home/.cache/$tb_install_folder"
    [ -n "$tb_temp_folder" ] || tb_temp_folder="$tb_cache_folder/temp"
    [ -n "$tb_downloaded_files_folder" ] || tb_downloaded_files_folder="$tb_cache_folder/files"
    [ -n "$tb_gpg_tmp_dir" ] || tb_gpg_tmp_dir="$tb_cache_folder/gpgtmpdir"
-   [ -n "$tb_extract_temp_folder" ] || tb_extract_temp_folder="$tb_cache_folder/tor-browser"
+   [ -n "$tb_extract_temp_folder" ] || tb_extract_temp_folder="$tb_cache_folder/"$tb_proxy_name-browser""
 
    if [ ! "$tb_updater_run" = "true" ]; then
       tb_exit_function 0
@@ -571,11 +579,11 @@ tb_preparation() {
 
    if [ "$tb_postinst" = "true" ]; then
       ## Being careful with deletion.
-      if [ "$tb_browser_folder" = "/var/cache/tb-binary/.tb/tor-browser" ]; then
+      if [ "$tb_browser_folder" = "/var/cache/tb-binary/.$tb_install_folder/"$tb_proxy_name-browser"" ]; then
          echo "rm -r -f '$tb_browser_folder'"
          rm -r -f "$tb_browser_folder"
       fi
-      if [ "$tb_downloaded_files_folder" = "/var/cache/tb-binary/.cache/tb/files" ]; then
+      if [ "$tb_downloaded_files_folder" = "/var/cache/tb-binary/.cache/$tb_install_folder/files" ]; then
          echo "rm -r -f '$tb_downloaded_files_folder'"
          rm -r -f "$tb_downloaded_files_folder"
       fi
@@ -958,7 +966,7 @@ tb_local_version_detection() {
 tb_confirm_update() {
    if [ "$qubes_vm_type" = "TemplateVM" ]; then
       local folder_name found
-      for folder_name in "/home/$who_ami/.tb" "/home/$who_ami/.cache/tb" ; do
+      for folder_name in "/home/$who_ami/.$tb_install_folder" "/home/$who_ami/.cache/$tb_install_folder" ; do
          if [ -d "$folder_name" ]; then
             found=true
             break
@@ -971,8 +979,8 @@ Otherwise updating Tor Browser in this TemplateVM will not result in newly creat
 <br />
 <br />To delete these obsolete folders, please run:
 <br />
-<br /><code>rm -r -f '/home/$who_ami/.tb'</code>
-<br /><code>rm -r -f '/home/$who_ami/.cache/tb'</code>
+<br /><code>rm -r -f '/home/$who_ami/.$tb_install_folder'</code>
+<br /><code>rm -r -f '/home/$who_ami/.cache/$tb_install_folder'</code>
 <br />
 <br />(Or delete them using a file manager.)
 <br />


### PR DESCRIPTION
This change adds an option, --i2p, and two new variables, tb_proxy_name and tb_install_folder, which allow the user to download a TBB to an i2p-specific path. They could easily be used to support other types of proxies in the future as well. Very soon, I should be ready to submit a patch to tb-starter to pre-configure the separate TBB to use i2p instead of Tor.