### PR TITLE
Tor Browser without Tor with normal browser settings.

### DIFF
--- a/usr/share/tb-updater/tb_without_tor_settings.js
+++ b/usr/share/tb-updater/tb_without_tor_settings.js
@@ -1,0 +1,20 @@
+// This file is part of Whonix
+// Copyright (C) 2012 - 2018 ENCRYPTED SUPPORT LP <adrelanos@riseup.net>
+// See the file COPYING for copying conditions.
+
+// Warning! These settings disable Tor. You will not be anonymous!
+
+// Configure Tor Browser without Tor settings for an everyday use 
+// security hardened browser. Take advantag of its excellent 
+// enhancements for reducing linkability, that is, "the ability
+// for a user's activity on one site to be linked with their 
+// activity on another site without their knowledge or explicit 
+// consent."
+// - See https://whonix.org/wiki/Tor_Browser_without_Tor
+
+// Disable Torbutton and Torlauncher extensions
+user_pref("extensions.torbutton.startup", false);
+user_pref("extensions.torlauncher.start_tor", false);
+// Normalize Tor Browser behavior
+user_pref("extensions.torbutton.noscript_persist", true);
+user_pref("browser.privatebrowsing.autostart", false);

--- a/usr/share/tb-updater/tb_without_tor_settings.js
+++ b/usr/share/tb-updater/tb_without_tor_settings.js
@@ -15,6 +15,7 @@
 // Disable Torbutton and Torlauncher extensions
 user_pref("extensions.torbutton.startup", false);
 user_pref("extensions.torlauncher.start_tor", false);
+user_pref("network.proxy.socks_remote_dns", false);
 // Normalize Tor Browser behavior
 user_pref("extensions.torbutton.noscript_persist", true);
 user_pref("browser.privatebrowsing.autostart", false);


### PR DESCRIPTION
PR as per [https://forums.whonix.org/t/todo-research-and-document-how-to-use-tor-browser-for-security-not-anonymity-how-to-use-tbb-using-clearnet/3822/37](url).

TorButton extension is not fully disabled so `"TOR_TRANSPROXY=1 torbrowser"` is required for networking. Cookies, bookmarks, and NoScipt behavior is normalized and persistent across TB restarts/VM reboots.  

