### PR TITLE
do not copy Tor Browser by default to user home at first boot

### DIFF
--- a/lib/systemd/system/tb-updater-first-boot.service
+++ b/lib/systemd/system/tb-updater-first-boot.service
@@ -2,7 +2,7 @@
 ## See the file COPYING for copying conditions.
 
 [Unit]
-Description=Copy Tor Browser from /var/cache/tb-binary to user home at First Boot Service
+Description=Helper Service for /usr/bin/torbrowser to determine when it is save to Copy Tor Browser from /var/cache/tb-binary to user home by Whonix developers
 Documentation=https://github.com/Whonix/tb-updater
 ConditionPathExists=!/var/run/qubes/this-is-templatevm
 
@@ -22,7 +22,7 @@ Before=qubes-gui-agent.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/lib/tb-updater/first-boot-home-population
+ExecStart=/bin/true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
because that wastes space in VMs that will never use Tor Browser

do it at actual first start of Tor Browser instead

/usr/lib/tb-updater/first-boot-home-population