### PR TITLE
remove passage about removed backup functionality from man page

### DIFF
--- a/man/update-i2pbrowser.1.ronn
+++ b/man/update-i2pbrowser.1.ronn
@@ -16,10 +16,6 @@ i2p network. It enforces TLS encryption (https) for
 TPO's website, downloads TBB from the TPO's website,
 and uses OpenPGP verification.
 
-In case there is already a `~/.i2pb` folder, it renames it
-to ~/.i2pb_(current date and time). It extracts freshly
-downloaded TBB too to `~/.i2pb/i2p-browser_(current date and time)`.
-
 Default action when no options are given is to performs an update check and ask
 how you want to proceed.
 

--- a/man/update-torbrowser.1.ronn
+++ b/man/update-torbrowser.1.ronn
@@ -15,10 +15,6 @@ from The Tor Project's (TPO) website. It enforces TLS encryption (https) for
 TPO's website, downloads TBB from the TPO's website,
 and uses OpenPGP verification.
 
-In case there is already a `~/.tb/tor-browser` folder, it renames it
-to `~/.tb/tor-browser_(current date and time)`. It extracts freshly
-downloaded TBB too to `~/.tb/tor-browser`.
-
 Default action when no options are given is to performs an update check and ask
 how you want to proceed.
 


### PR DESCRIPTION
fixes #14 

Dont know about the markdown source files, but given the ease of patch its trivial to correct regardless